### PR TITLE
Jwscook/continuedfractionimprovement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypergeometricFunctions"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"

--- a/src/gauss.jl
+++ b/src/gauss.jl
@@ -198,6 +198,6 @@ function mFncontinuedfraction(a::AbstractVector{S}, b::AbstractVector{U}, z::V) 
   numerator(i) = - z * prod(i .+ a) / prod(i .+ b) / (i + 1)
   denominator(i) = 1 - numerator(i)
   K = continuedfraction(denominator, numerator, 10eps(real(T))) - denominator(0)
-  iszero(K + 1) && error("Non convergence of continued fraction; inputs $a, $b, $z")
+  # iszero(K + 1) leads to Inf, when e.g. Float64s run out of digits
   return 1 + z * prod(a) / prod(b) / (1 + K)
 end

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -508,7 +508,7 @@ function continuedfraction(v::V, u::U, rtol::T
     b = continuedfraction(v, u, n)
   end
   isapprox(a, b, rtol=rtol) && return b
-  error("No convergence of generalized hypergeometric function")
+  error("Convergence failure for continued fraction for hypergeometric function")
 end
 function continuedfraction(v::V, u::U, n::Int, m::Int
     ) where {V<:Function, U<:Function}

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -499,13 +499,15 @@ rtoldefault(x::Union{T, Type{T}}, y::Union{S, Type{S}}) where {T<:Number, S<:Num
 function continuedfraction(v::V, u::U, rtol::T
     ) where {V<:Function, U<:Function, T<:Number}
   n = 4
-  a, b = continuedfraction(v, u, n, n + 1)
-  isapprox(a, b, rtol=rtol) && return b
+  a, b = continuedfraction(v, u, n, 2n)
+  n *= 2
   while n <= 2^16
-    a, b = continuedfraction(v, u, n, n + 1)
     isapprox(a, b, rtol=rtol) && return b
-    n *= 4
+    n *= 2
+    a = deepcopy(b)
+    b = continuedfraction(v, u, n)
   end
+  isapprox(a, b, rtol=rtol) && return b
   error("No convergence of generalized hypergeometric function")
 end
 function continuedfraction(v::V, u::U, n::Int, m::Int
@@ -525,4 +527,11 @@ function continuedfraction(v::V, u::U, n::Int, m::Int
   end
   vi = v(0)
   return vi + output_n, vi + output_m
+end
+function continuedfraction(v::V, u::U, n::Int) where {V<:Function, U<:Function}
+  output = u(n) / v(n)
+  for i ∈ reverse(1:n-1)
+    output = u(i) / (v(i) + output)
+  end
+  return v(0) + output
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -193,6 +193,7 @@ const NumberType = Float64
     @test mFn(a, b, c) ≈ result atol=eps() rtol=rtol
     (a, b, c, result) = NumberType.([2.36231, -0.901808, 1.00893]), NumberType.([1.39985, -2.34968]), NumberType(0.970806084927347), 42731.87930657499
     @test_broken mFn(a, b, c) ≈ result atol=eps() rtol=rtol
+    @test HypergeometricFunctions.mFncontinuedfraction(a, b, c) ≈ result atol=eps() rtol=rtol
     (a, b, c, result) = NumberType.([-0.715302, 2.94101, -0.498188]), NumberType.([-0.393808, -0.0265878]), NumberType(0.4375358657735875), 61.68955383799459
     @test mFn(a, b, c) ≈ result atol=eps() rtol=rtol
     (a, b, c, result) = NumberType.([-1.14105, 1.9464, -2.44787]), NumberType.([0.54636, -0.654353]), NumberType(-2.9505198429994763), -53.189709409599516


### PR DESCRIPTION
I noticed an improvement in convergence could be made to the continued fraction implementation.

I also corrected a misconception about the cause of an `Inf` - it's actually a legitimate `Inf` when e.g. Float64s run out of digits.

Also, the broken test passes when the continued fraction implementation is used.