### PR TITLE
Change fallback unsafe_gamma for x::Real to x<:AbstractFloat. Add

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypergeometricFunctions"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -141,7 +141,6 @@ const libm = Base.libm_name
 
 unsafe_gamma(x::Float64) = ccall((:tgamma, libm),  Float64, (Float64, ), x)
 unsafe_gamma(x::Float32) = ccall((:tgammaf, libm),  Float32, (Float32, ), x)
-#unsafe_gamma(x::T) where{T<:AbstractFloat} = unsafe_gamma(x)
 function unsafe_gamma(x::BigFloat)
     z = BigFloat()
     ccall((:mpfr_gamma, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Int32), z, x, Base.MPFR.ROUNDING_MODE[])

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -141,7 +141,7 @@ const libm = Base.libm_name
 
 unsafe_gamma(x::Float64) = ccall((:tgamma, libm),  Float64, (Float64, ), x)
 unsafe_gamma(x::Float32) = ccall((:tgammaf, libm),  Float32, (Float32, ), x)
-unsafe_gamma(x::T) where{T<:AbstractFloat} = unsafe_gamma(float(x))
+unsafe_gamma(x::T) where{T<:AbstractFloat} = unsafe_gamma(x)
 function unsafe_gamma(x::BigFloat)
     z = BigFloat()
     ccall((:mpfr_gamma, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Int32), z, x, Base.MPFR.ROUNDING_MODE[])

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -141,7 +141,7 @@ const libm = Base.libm_name
 
 unsafe_gamma(x::Float64) = ccall((:tgamma, libm),  Float64, (Float64, ), x)
 unsafe_gamma(x::Float32) = ccall((:tgammaf, libm),  Float32, (Float32, ), x)
-unsafe_gamma(x::Real) = unsafe_gamma(float(x))
+unsafe_gamma(x::T) where{T<:AbstractFloat} = unsafe_gamma(float(x))
 function unsafe_gamma(x::BigFloat)
     z = BigFloat()
     ccall((:mpfr_gamma, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Int32), z, x, Base.MPFR.ROUNDING_MODE[])
@@ -149,7 +149,7 @@ function unsafe_gamma(x::BigFloat)
 end
 unsafe_gamma(z::Complex) = gamma(z)
 unsafe_gamma(z::Dual) = (r = realpart(z);w = unsafe_gamma(r); dual(w, w*digamma(r)*dualpart(z)))
-
+unsafe_gamma(z) = gamma(z) 
 """
     @lanczosratio(z, ϵ, c₀, c...)
 

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -141,13 +141,12 @@ const libm = Base.libm_name
 
 unsafe_gamma(x::Float64) = ccall((:tgamma, libm),  Float64, (Float64, ), x)
 unsafe_gamma(x::Float32) = ccall((:tgammaf, libm),  Float32, (Float32, ), x)
-unsafe_gamma(x::T) where{T<:AbstractFloat} = unsafe_gamma(x)
+#unsafe_gamma(x::T) where{T<:AbstractFloat} = unsafe_gamma(x)
 function unsafe_gamma(x::BigFloat)
     z = BigFloat()
     ccall((:mpfr_gamma, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Int32), z, x, Base.MPFR.ROUNDING_MODE[])
     return z
 end
-unsafe_gamma(z::Complex) = gamma(z)
 unsafe_gamma(z::Dual) = (r = realpart(z);w = unsafe_gamma(r); dual(w, w*digamma(r)*dualpart(z)))
 unsafe_gamma(z) = gamma(z) 
 """


### PR DESCRIPTION
This PR tweaks the behavior of `unsafe_gamma` to avoid stack overflow errors with ForwardDiff.jl. The method `unsafe_gamma(x::Real) = unsafe_gamma(float(x))` has been given different type bounds as that particular dispatch method seems prone to these issues (ref [JuliaLang/julia#26552](https://github.com/JuliaLang/julia/issues/26552)). Further adds a generic fallback to `gamma` from SpecialFunctions.jl.

This design decision may not be coherent with other choices here, like manually implementing `unsafe_gamma(x::Dual)`, so please let me know if this is not acceptable. There is some discussion available on the issue [here](https://github.com/JuliaMath/HypergeometricFunctions.jl/issues/27). This method avoids needing to make ForwardDiff or DiffRules a new dependency.