### PR TITLE
Use OpenLibm explicitly, to prepare for its excision from base.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
           - '^1.8.0-0'
           - 'nightly'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         version:
           - '1.0'
           - '1'
-          - '^1.8.0-0'          
+          - '^1.8.0-0'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -23,6 +23,10 @@ jobs:
           - windows-latest
         arch:
           - x64
+          - x86
+        exclude:
+          - os: macOS-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,9 @@
 name = "HypergeometricFunctions"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.10"
+version = "0.3.11"
 
 [deps]
+OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/Project.toml
+++ b/Project.toml
@@ -12,4 +12,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 DualNumbers = "0.6.3, 0.7"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 2"
-julia = "1"
+julia = "1.3"

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -1,3 +1,5 @@
+using OpenLibm_jll
+
 @inline norm2(x) = norm(x)
 @inline norm2(x::Dual) = hypot(x.value, x.epsilon)
 
@@ -140,7 +142,7 @@ speciallogseries(x::Union{ComplexF64, DualComplex256}) = @evalpoly(x, 1.00000000
 
 tanpi(z) = sinpi(z)/cospi(z)
 
-const libm = Base.libm_name
+const libm = OpenLibm_jll.libopenlibm
 
 unsafe_gamma(x::Float64) = ccall((:tgamma, libm),  Float64, (Float64, ), x)
 unsafe_gamma(x::Float32) = ccall((:tgammaf, libm),  Float32, (Float32, ), x)


### PR DESCRIPTION
Preparing for https://github.com/JuliaLang/julia/pull/42299. Eventually, we will remove OpenLibm_jll from base altogether, but having OpenLibm_jll in the Project.toml will ensure that things do not break.

Add 32-bit platforms to the CI.

Bump julia compat to 1.3, since that's what we need for OpenLibm_jll.