### PR TITLE
Minor housekeeping items (NFC)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,6 @@ jobs:
         version:
           - '1.3'
           - '1'
-          - '^1.8.0-0'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -33,16 +32,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,18 @@ uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 version = "0.3.11"
 
 [deps]
-OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DualNumbers = "0.6.3, 0.7"
+DualNumbers = "0.6.3"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 2"
 julia = "1.3"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
Summary of changes:
- Test is now a test-only dependency rather than a direct dependency
- There is no DualNumbers 0.7 so the declaration of compatibility with it has been removed
- GitHub Actions now uses the Julia-specific `julia-actions/cache`
- GitHub Actions no longer tests on `^1.8.0-0`, which is currently the same as `1`