### PR TITLE
Fix codecov integration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,3 +37,5 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
#77 broke codecov integration (see eg https://github.com/JuliaMath/HypergeometricFunctions.jl/actions/runs/9020940540/job/24787174800#step:8:32): version 4 does not allow tokenless uploads anymore.